### PR TITLE
Add Stripe payments dashboard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+.env

--- a/dashboard.html
+++ b/dashboard.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Stripe Payments Dashboard</title>
+  <style>
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ccc; padding: 8px; }
+    th { background: #f2f2f2; }
+  </style>
+</head>
+<body>
+  <h1>Stripe Payments</h1>
+  <table id="payments-table">
+    <thead>
+      <tr>
+        <th>Name</th>
+        <th>Email</th>
+        <th>Patients Address</th>
+        <th>State</th>
+        <th>Program Number</th>
+        <th>Invoice Closed</th>
+        <th>Order Placed By</th>
+        <th>Prescriber</th>
+        <th>Comments</th>
+        <th>Stripe Invoice</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+
+  <script>
+    async function loadPayments() {
+      const res = await fetch('/api/stripe-payments');
+      const payments = await res.json();
+      const tbody = document.querySelector('#payments-table tbody');
+      payments.forEach(p => {
+        const tr = document.createElement('tr');
+        const link = p.stripeInvoice ? `<a href="${p.stripeInvoice}" target="_blank">View</a>` : '';
+        tr.innerHTML = `
+          <td>${p.name}</td>
+          <td>${p.email}</td>
+          <td>${p.patientAddress}</td>
+          <td>${p.state}</td>
+          <td>${p.programNumber}</td>
+          <td>${p.invoiceClosed}</td>
+          <td>${p.orderPlacedBy}</td>
+          <td>${p.prescriber}</td>
+          <td>${p.comments}</td>
+          <td>${link}</td>`;
+        tbody.appendChild(tr);
+      });
+    }
+
+    loadPayments();
+  </script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "stripe-dashboard",
+  "version": "1.0.0",
+  "description": "Dashboard to display Stripe payments",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.19.2",
+    "stripe": "^14.23.0"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,49 @@
+const express = require('express');
+const Stripe = require('stripe');
+
+const app = express();
+const port = process.env.PORT || 3000;
+const stripeSecret = process.env.STRIPE_SECRET_KEY;
+
+let stripe;
+if (stripeSecret) {
+  stripe = new Stripe(stripeSecret, { apiVersion: '2023-10-16' });
+} else {
+  console.warn('STRIPE_SECRET_KEY not set; /api/stripe-payments will return empty data');
+}
+
+app.get('/api/stripe-payments', async (req, res) => {
+  if (!stripe) {
+    return res.json([]);
+  }
+  try {
+    const invoices = await stripe.invoices.list({ limit: 10 });
+    const results = invoices.data.map(inv => {
+      const customer = inv.customer_details || {};
+      const addr = customer.address || {};
+      const metadata = inv.metadata || {};
+      return {
+        name: customer.name || '',
+        email: customer.email || '',
+        patientAddress: [addr.line1, addr.line2, addr.city, addr.postal_code].filter(Boolean).join(', '),
+        state: addr.state || '',
+        programNumber: metadata.program_number || '',
+        invoiceClosed: inv.status === 'paid' ? 'Yes' : 'No',
+        orderPlacedBy: metadata.order_placed_by || '',
+        prescriber: metadata.prescriber || '',
+        comments: metadata.comments || '',
+        stripeInvoice: inv.hosted_invoice_url || ''
+      };
+    });
+    res.json(results);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Failed to retrieve invoices' });
+  }
+});
+
+app.use(express.static('.'));
+
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`);
+});


### PR DESCRIPTION
## Summary
- add Express server to expose `/api/stripe-payments` endpoint
- create dashboard UI that displays Stripe invoices in a spreadsheet-like table
- initialize Node project with dependencies and ignore node_modules

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `node server.js` *(fails: Cannot find module 'express')*


------
https://chatgpt.com/codex/tasks/task_e_68ab662a13888330a39fd23f2d64b57a